### PR TITLE
Switch to is_authenticated2 method

### DIFF
--- a/radicale_dovecot_auth/__init__.py
+++ b/radicale_dovecot_auth/__init__.py
@@ -45,6 +45,9 @@ class Auth(BaseAuth):
         return DovecotAuth(
                 self.configuration.get('auth', 'auth_socket'), SERVICE)
 
+    def is_authenticated(self, user, password):
+        return self.is_authenticated2(None, user, password)
+
     def is_authenticated2(self, login, user, password):
         conn = self.get_connection()
         return conn.authenticate(user, password)

--- a/radicale_dovecot_auth/__init__.py
+++ b/radicale_dovecot_auth/__init__.py
@@ -45,6 +45,6 @@ class Auth(BaseAuth):
         return DovecotAuth(
                 self.configuration.get('auth', 'auth_socket'), SERVICE)
 
-    def is_authenticated(self, user, password):
+    def is_authenticated2(self, login, user, password):
         conn = self.get_connection()
         return conn.authenticate(user, password)


### PR DESCRIPTION
is_authenticated has been marked as deprecated in Radicale. Switched to is_authenticated2 instead.
I also moved the socket creation in __init__ to avoid generating a connection to the socket each time you call the authentification method.