### PR TITLE
fix not setting auth_host and auth_port

### DIFF
--- a/radicale_dovecot_auth/__init__.py
+++ b/radicale_dovecot_auth/__init__.py
@@ -45,6 +45,7 @@ class Auth(BaseAuth):
 
         with suppress(KeyError):
             kwargs['socket_path'] = self.configuration.get('auth', 'auth_socket')
+        with suppress(KeyError):
             kwargs['host'] = self.configuration.get('auth', 'auth_host')
             kwargs['port'] = self.configuration.get('auth', 'auth_port')
 


### PR DESCRIPTION
If auth_socket is not set, the plugin doesn't try to set auth_host and auth_port (because it then breaks out of the with block).

I assume this is not the intended behavior. So I added another block to fix it.

Looks like you are not using tcp socket? :)