### PR TITLE
Error out the socket path

### DIFF
--- a/radicale_dovecot_auth/dovecot_auth.py
+++ b/radicale_dovecot_auth/dovecot_auth.py
@@ -67,7 +67,15 @@ class DovecotAuth:
         self.service = service
 
         if socket_path:
-            self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            except OSError as error:
+                e = sys.exc_info()[1]
+                assert e is not None
+                logger.error("Not enough permissions to create unix socket: %s",
+                         sys.exc_info()[1], exc_info=True)
+                raise error
+                
             try:
                 self.socket.connect(self.socket_path)
             except PermissionError:

--- a/radicale_dovecot_auth/dovecot_auth.py
+++ b/radicale_dovecot_auth/dovecot_auth.py
@@ -15,8 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from base64 import b64encode
+from radicale.log import logger
 import os
 import socket
+import sys
 
 HANDSHAKE = "VERSION\t1\t1\nCPID\t{}\n"
 SUPPORTED_MAJOR_VERSION = 1
@@ -66,7 +68,14 @@ class DovecotAuth:
 
         if socket_path:
             self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.socket.connect(self.socket_path)
+            try:
+                self.socket.connect(self.socket_path)
+            except PermissionError:
+                e = sys.exc_info()[1]
+                assert e is not None
+                logger.error("Could not connect to %s: %s",
+                         self.socket_path, sys.exc_info()[1], exc_info=True)
+                raise error
 
         elif host and port:
             self.socket = socket.create_connection((host, port))


### PR DESCRIPTION
Previous message was a bit ambiguous:
```
[1793065/Thread-3 (process_request_thread)] [ERROR] An exception occurred during PROPFIND request on '/': [Errno 13] Permission denied
```

Even with `level = debug` it wouldn't show the path specifically which might come in handy *(mainly to see that it's actually using the configured path)*
This will output more details explaining why and where:
```
[1793065/Thread-3 (process_request_thread)] [ERROR] Could not connect to /var/spool/postfix/private/radicaleauth: [Errno 13] Permission denied
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/radicale_dovecot_auth/dovecot_auth.py", line 72, in __init__
    self.socket.connect(self.socket_path)
PermissionError: [Errno 13] Permission denied
```

As well as improve the creation of sockets:
```
[1793065/Thread-3 (process_request_thread)] [ERROR] Not enough permissions to create unix socket: [Errno 97] Address family not supported by protocol
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/radicale_dovecot_auth/dovecot_auth.py", line 71, in __init__
    self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
  File "/usr/lib/python3.10/socket.py", line 232, in __init__
    _socket.socket.__init__(self, family, type, proto, fileno)
OSError: [Errno 97] Address family not supported by protocol
```

The second error usually happens due to the hardening guide of `radicale` itself, where the `.service` file prohibits creation of UNIX sockets by default:
```ini
RestrictAddressFamilies=~AF_PACKET AF_NETLINK AF_UNIX
```
And if you forget to do the necessary change this error was a bit vague, this will give a friendly nudge of where to look and add:
```ini
RestrictAddressFamilies=
RestrictAddressFamilies=~AF_PACKET AF_NETLINK
```